### PR TITLE
Added context configuration to allow or bypass Relay check when local

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,25 +72,28 @@ const snapshotLocation = './snapshot/';
 const snapshotAutoUpdateInterval = 3;
 const snapshotWatcher = true;
 const silentMode = '5m';
+const restrictRelay = true;
 const certPath = './certs/ca.pem';
 
 Client.buildContext({ url, apiKey, domain, component, environment }, {
-    local, logger, snapshotLocation, snapshotAutoUpdateInterval, snapshotWatcher, silentMode, certPath
+    local, logger, snapshotLocation, snapshotAutoUpdateInterval, 
+    snapshotWatcher, silentMode, restrictRelay, certPath
 });
 
 const switcher = Client.getSwitcher();
 ```
 
-- **local**: If activated, the client will only fetch the configuration inside your snapshot file. The default value is 'false'.
+- **local**: If activated, the client will only fetch the configuration inside your snapshot file. The default value is 'false'
 - **logger**: If activated, it is possible to retrieve the last results from a given Switcher key using Client.getLogger('KEY')
-- **snapshotLocation**: Location of snapshot files.
-- **snapshotAutoUpdateInterval**: Enable Snapshot Auto Update given an interval in seconds (default: 0 disabled).
-- **snapshotWatcher**: Enable Snapshot Watcher to monitor changes in the snapshot file (default: false).
+- **snapshotLocation**: Location of snapshot files
+- **snapshotAutoUpdateInterval**: Enable Snapshot Auto Update given an interval in seconds (default: 0 disabled)
+- **snapshotWatcher**: Enable Snapshot Watcher to monitor changes in the snapshot file (default: false)
 - **silentMode**: Enable contigency given the time for the client to retry - e.g. 5s (s: seconds - m: minutes - h: hours)
-- **regexSafe**: Enable REGEX Safe mode - Prevent agaist reDOS attack (default: true).
+- **restrictRelay**: Enable Relay Restriction - Allow managing Relay restrictions when running in local mode (default: true)
+- **regexSafe**: Enable REGEX Safe mode - Prevent agaist reDOS attack (default: true)
 - **regexMaxBlackList**: Number of entries cached when REGEX Strategy fails to perform (reDOS safe) - default: 50
 - **regexMaxTimeLimit**: Time limit (ms) used by REGEX workers (reDOS safe) - default - 3000ms
-- **certPath**: Path to the certificate file used to establish a secure connection with the API.
+- **certPath**: Path to the certificate file used to establish a secure connection with the API
 
 (*) regexSafe is a feature that prevents your application from being exposed to a reDOS attack. It is recommended to keep this feature enabled.<br>
 However, this feature uses Web Worker API which is currently not compatible with compiled executables.

--- a/src/client.ts
+++ b/src/client.ts
@@ -71,6 +71,9 @@ export class Client {
       [SWITCHER_OPTIONS.SILENT_MODE]: () => {
         if (options.silentMode) this._initSilentMode(options.silentMode);
       },
+      [SWITCHER_OPTIONS.RESTRICT_RELAY]: () => {
+        GlobalOptions.updateOptions({ restrictRelay: options.restrictRelay });
+      },
       [SWITCHER_OPTIONS.SNAPSHOT_AUTO_UPDATE_INTERVAL]: () => {
         GlobalOptions.updateOptions({ snapshotAutoUpdateInterval: options.snapshotAutoUpdateInterval });
         this.scheduleSnapshotAutoUpdate();
@@ -116,7 +119,8 @@ export class Client {
    * Creates a new instance of Switcher
    */
   static getSwitcher(key?: string): Switcher {
-    return new Switcher(util.get(key, ''));
+    return new Switcher(util.get(key, ''))
+      .restrictRelay(GlobalOptions.restrictRelay);
   }
 
   /**

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,6 +9,7 @@ export enum SWITCHER_OPTIONS {
   SNAPSHOT_LOCATION = 'snapshotLocation',
   SNAPSHOT_AUTO_UPDATE_INTERVAL = 'snapshotAutoUpdateInterval',
   SNAPSHOT_WATCHER = 'snapshotWatcher',
+  RESTRICT_RELAY = 'restrictRelay',
   SILENT_MODE = 'silentMode',
   REGEX_SAFE = 'regexSafe',
   REGEX_MAX_BLACK_LIST = 'regexMaxBlackList',

--- a/src/lib/globals/globalOptions.ts
+++ b/src/lib/globals/globalOptions.ts
@@ -35,4 +35,8 @@ export class GlobalOptions {
   static get silentMode() {
     return this.options.silentMode;
   }
+
+  static get restrictRelay() {
+    return this.options.restrictRelay;
+  }
 }

--- a/src/lib/remote.ts
+++ b/src/lib/remote.ts
@@ -176,6 +176,7 @@ export const resolveSnapshot = async (
           group { name activated
             config { key activated
               strategies { strategy activated operation values }
+              relay { type activated }
               components
             }
           }

--- a/src/switcher.ts
+++ b/src/switcher.ts
@@ -23,6 +23,7 @@ export class Switcher {
   private _defaultResult: boolean | undefined;
   private _forceRemote = false;
   private _showDetail = false;
+  private _restrictRelay = true;
 
   constructor(key: string) {
     this._validateArgs(key);
@@ -144,6 +145,14 @@ export class Switcher {
    */
   defaultResult(defaultResult: boolean): this {
     this._defaultResult = defaultResult;
+    return this;
+  }
+
+  /**
+   * Allow local snapshots to ignore or require Relay verification.
+   */
+  restrictRelay(restrict = true): this {
+    this._restrictRelay = restrict;
     return this;
   }
 
@@ -280,11 +289,7 @@ export class Switcher {
     let response: ResultDetail;
 
     try {
-      response = await checkCriteriaLocal(
-        GlobalSnapshot.snapshot,
-        util.get(this._key, ''),
-        util.get(this._input, []),
-      );
+      response = await checkCriteriaLocal(GlobalSnapshot.snapshot, this);
     } catch (err) {
       response = this.getDefaultResultOrThrow(err as Error);
     }
@@ -336,5 +341,12 @@ export class Switcher {
    */
   get input(): string[][] | undefined {
     return this._input;
+  }
+
+  /**
+   * Return Relay restriction value
+   */
+  get isRelayRestricted(): boolean {
+    return this._restrictRelay;
   }
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -66,6 +66,11 @@ export type SwitcherOptions = {
   snapshotWatcher?: boolean;
 
   /**
+   * Allow local snapshots to ignore or require Relay verification.
+   */
+  restrictRelay?: boolean;
+
+  /**
    * When defined it will switch to local during the specified time before it switches back to remote
    * e.g. 5s (s: seconds - m: minutes - h: hours)
    */
@@ -159,6 +164,7 @@ export type Config = {
   key: string;
   activated: boolean;
   strategies: Strategy[];
+  relay: Relay;
 };
 
 export type Strategy = {
@@ -171,6 +177,11 @@ export type Strategy = {
 export type Entry = {
   strategy: string;
   input: string;
+};
+
+export type Relay = {
+  type: string;
+  activated: boolean;
 };
 
 /**

--- a/tests/snapshot/default.json
+++ b/tests/snapshot/default.json
@@ -127,6 +127,33 @@
                             "components": []
                         }
                     ]
+                },
+                {
+                    "name": "Relay test",
+                    "description": "Relay group",
+                    "activated": true,
+                    "config": [
+                        {
+                            "key": "USECASE103",
+                            "description": "Relay enabled",
+                            "activated": true,
+                            "relay": {
+                                "type": "VALIDATOR",
+                                "activated": true
+                            },
+                            "components": []
+                        },
+                        {
+                            "key": "USECASE104",
+                            "description": "Relay disabled",
+                            "relay": {
+                                "type": "VALIDATOR",
+                                "activated": false
+                            },
+                            "activated": true,
+                            "components": []
+                        }
+                    ]
                 }
             ]
         }

--- a/tests/switcher-client.test.ts
+++ b/tests/switcher-client.test.ts
@@ -315,3 +315,56 @@ describe('E2E test - Client testing (assume) feature:', function () {
   });
 
 });
+
+describe('E2E test - Restrict Relay:', function () {
+  beforeAll(async function() {
+    Client.buildContext({ url, apiKey, domain, component, environment }, {
+      snapshotLocation, local: true, logger: true, regexMaxBlackList: 1, regexMaxTimeLimit: 500
+    });
+
+    await Client.loadSnapshot();
+  });
+
+  afterAll(function() {
+    Client.unloadSnapshot();
+    TimedMatch.terminateWorker();
+  });
+
+  beforeEach(function() {
+    Client.clearLogger();
+  });
+
+  it('should return false when Relay is enabled (restrict default: true)', testSettings, async function () {
+    Client.buildContext({ domain, component, environment }, {
+      snapshotLocation, local: true, logger: true
+    });
+
+    await Client.loadSnapshot();
+
+    switcher = Client.getSwitcher();
+    assertFalse(await switcher.isItOn('USECASE103'));
+  });
+
+  it('should return true when Relay is enabled (restrict: false)', testSettings, async function () {
+    Client.buildContext({ domain, component, environment }, {
+      snapshotLocation, local: true, logger: true, restrictRelay: false
+    });
+
+    await Client.loadSnapshot();
+
+    switcher = Client.getSwitcher();
+    assertTrue(await switcher.isItOn('USECASE103'));
+  });
+
+  it('should return true when Relay is disabled (restrict: true)', testSettings, async function () {
+    Client.buildContext({ domain, component, environment }, {
+      snapshotLocation, local: true, logger: true, restrictRelay: true
+    });
+
+    await Client.loadSnapshot();
+
+    switcher = Client.getSwitcher();
+    assertTrue(await switcher.isItOn('USECASE104'));
+  });
+
+});

--- a/tests/switcher-functional.test.ts
+++ b/tests/switcher-functional.test.ts
@@ -375,7 +375,7 @@ describe('Integrated test - Client:', function () {
       assertTrue(await switcher.isItOn());
     });
 
-    it('should not throw when switcher keys provided were configured properly', async function() {
+    it('should NOT throw when switcher keys provided were configured properly', async function() {
       //given
       given('POST@/criteria/auth', generateAuth('[auth_token]', 5));
       given('POST@/criteria/switchers_check', { not_found: [] });

--- a/tests/switcher-snapshot.test.ts
+++ b/tests/switcher-snapshot.test.ts
@@ -291,7 +291,7 @@ describe('E2E test - Client local - Snapshot:', function () {
     assertExists(GlobalSnapshot.snapshot);
   });
 
-  it('should not throw when switcher keys provided were configured properly', testSettings, async function () {
+  it('should NOT throw when switcher keys provided were configured properly', testSettings, async function () {
     await delay(2000);
     
     await Client.loadSnapshot();


### PR DESCRIPTION
New context option available for relay verification check (default true).

```ts
Client.buildContext({ domain, component, environment }, {
    restrictRelay: true
});
```

This configuration allows you to ensure Switcher Relays are verified when local, which can prevent false-positive flag result as Relays are only evaluated when using remote mode.
It can be bypassed with "false" if they are optional for the environment the Switcher is being evaluated.