### PR TITLE
Added Client.snapshotVersion(), replaced snapshot() for security matters

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -390,4 +390,11 @@ export class Client {
   static testMode(testEnabled: boolean = true): void {
     Client._testEnabled = testEnabled;
   }
+
+  /**
+   * Returns the current snapshot version.
+   */
+  static get snapshotVersion(): number {
+    return GlobalSnapshot.snapshot?.data.domain.version || 0;
+  }
 }

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -5,8 +5,9 @@ export {
     assertRejects, 
     assertExists, 
     assertNotEquals, 
+    assertGreater,
     assertArrayIncludes 
-} from 'jsr:@std/assert@1.0.13';;
+} from 'jsr:@std/assert@1.0.13';
 export { assertSpyCalls, spy } from 'jsr:@std/testing@1.0.13/mock';
 export { 
     describe, 

--- a/tests/switcher-client.test.ts
+++ b/tests/switcher-client.test.ts
@@ -203,7 +203,7 @@ describe('E2E test - Client local #1:', function () {
 
     Client.testMode();
     
-    //test
+    // test
     await assertRejects(async () =>
       await Client.loadSnapshot(), 
       Error, 'Something went wrong: It was not possible to load the file at //somewhere/');

--- a/tests/switcher-functional.test.ts
+++ b/tests/switcher-functional.test.ts
@@ -382,11 +382,11 @@ describe('Integrated test - Client:', function () {
     });
 
     it('should NOT throw when switcher keys provided were configured properly', async function() {
-      //given
+      // given
       given('POST@/criteria/auth', generateAuth('[auth_token]', 5));
       given('POST@/criteria/switchers_check', { not_found: [] });
 
-      //test
+      // test
       Client.buildContext(contextSettings);
 
       let error: Error | undefined;
@@ -395,11 +395,11 @@ describe('Integrated test - Client:', function () {
     });
 
     it('should throw when switcher keys provided were not configured properly', async function() {
-      //given
+      // given
       given('POST@/criteria/auth', generateAuth('[auth_token]', 5));
       given('POST@/criteria/switchers_check', { not_found: ['FEATURE02'] });
 
-      //test
+      // test
       Client.buildContext(contextSettings);
       await assertRejects(async () =>
         await Client.checkSwitchers(['FEATURE01', 'FEATURE02']),
@@ -407,11 +407,11 @@ describe('Integrated test - Client:', function () {
     });
 
     it('should throw when no switcher keys were provided', async function() {
-      //given
+      // given
       given('POST@/criteria/auth', generateAuth('[auth_token]', 5));
       given('POST@/criteria/switchers_check', undefined, 422);
 
-      //test
+      // test
       Client.buildContext(contextSettings);
       await assertRejects(async () =>
         await Client.checkSwitchers([]),


### PR DESCRIPTION
### Feature additions:

* [`src/client.ts`](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12R393-R399): Added a static `snapshotVersion` getter to the `Client` class, which retrieves the current snapshot version from `GlobalSnapshot`. This API replaces the old `Client.snapshot()`, which could leak sensitive data from Strategy values. The snapshot version can be used to log or validate latest changes in runtime.