### PR TITLE
chore: moved snapshotWatcher from client to lib

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -7,16 +7,19 @@
     "jsr:@std/fs@1.0.16": "1.0.16",
     "jsr:@std/fs@1.0.17": "1.0.17",
     "jsr:@std/fs@1.0.18": "1.0.18",
+    "jsr:@std/fs@1.0.19": "1.0.19",
     "jsr:@std/fs@1.0.2": "1.0.2",
     "jsr:@std/fs@1.0.4": "1.0.4",
     "jsr:@std/fs@1.0.5": "1.0.5",
     "jsr:@std/fs@1.0.6": "1.0.6",
+    "jsr:@std/internal@^1.0.9": "1.0.9",
     "jsr:@std/path@^1.0.3": "1.0.3",
     "jsr:@std/path@^1.0.6": "1.0.6",
     "jsr:@std/path@^1.0.7": "1.0.8",
     "jsr:@std/path@^1.0.8": "1.0.8",
     "jsr:@std/path@^1.0.9": "1.0.9",
-    "jsr:@std/path@^1.1.0": "1.1.0"
+    "jsr:@std/path@^1.1.0": "1.1.0",
+    "jsr:@std/path@^1.1.1": "1.1.1"
   },
   "jsr": {
     "@std/fs@1.0.2": {
@@ -79,6 +82,16 @@
         "jsr:@std/path@^1.1.0"
       ]
     },
+    "@std/fs@1.0.19": {
+      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
+      "dependencies": [
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.1"
+      ]
+    },
+    "@std/internal@1.0.9": {
+      "integrity": "bdfb97f83e4db7a13e8faab26fb1958d1b80cc64366501af78a0aee151696eb8"
+    },
     "@std/path@1.0.3": {
       "integrity": "cd89d014ce7eb3742f2147b990f6753ee51d95276bfc211bc50c860c1bc7df6f"
     },
@@ -93,6 +106,12 @@
     },
     "@std/path@1.1.0": {
       "integrity": "ddc94f8e3c275627281cbc23341df6b8bcc874d70374f75fec2533521e3d6886"
+    },
+    "@std/path@1.1.1": {
+      "integrity": "fe00026bd3a7e6a27f73709b83c607798be40e20c81dde655ce34052fd82ec76",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
     }
   }
 }

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,1 +1,1 @@
-export { existsSync } from 'jsr:@std/fs@1.0.18';
+export { existsSync } from 'jsr:@std/fs@1.0.19';

--- a/src/lib/snapshotWatcher.ts
+++ b/src/lib/snapshotWatcher.ts
@@ -1,0 +1,67 @@
+import { DEFAULT_ENVIRONMENT } from './constants.ts';
+import { GlobalOptions } from './globals/globalOptions.ts';
+import { GlobalSnapshot } from './globals/globalSnapshot.ts';
+import { loadDomain } from './snapshot.ts';
+import * as util from './utils/index.ts';
+
+/**
+ * SnapshotWatcher is a utility class that watches for changes in the snapshot file
+ * and triggers a callback when the file is modified.
+ */
+export class SnapshotWatcher {
+  private _watcher: Deno.FsWatcher | undefined;
+  private readonly _watchDebounce = new Map<string, number>();
+
+  async watchSnapshot(environment: string, callback: {
+    success?: () => void | Promise<void>;
+    reject?: (err: Error) => void;
+  } = {}): Promise<void> {
+    const { success = () => {}, reject = () => {} } = callback;
+
+    const snapshotFile = `${GlobalOptions.snapshotLocation}/${environment}.json`;
+    this._watcher = Deno.watchFs(snapshotFile);
+    for await (const event of this._watcher) {
+      const dataString = JSON.stringify(event);
+      if (this._watchDebounce.has(dataString)) {
+        clearTimeout(this._watchDebounce.get(dataString));
+        this._watchDebounce.delete(dataString);
+      }
+
+      this._watchDebounce.set(
+        dataString,
+        setTimeout(() => this._onModifySnapshot(environment, dataString, event, success, reject), 20),
+      );
+    }
+  }
+
+  stopWatching(): void {
+    if (this._watcher) {
+      this._watchDebounce.clear();
+      this._watcher.close();
+      this._watcher = undefined;
+    }
+  }
+
+  private _onModifySnapshot(
+    environment: string,
+    dataString: string,
+    event: Deno.FsEvent,
+    success: () => void | Promise<void>,
+    error: (err: Error) => void,
+  ) {
+    try {
+      this._watchDebounce.delete(dataString);
+
+      if (event.kind === 'modify') {
+        GlobalSnapshot.init(loadDomain(
+          util.get(GlobalOptions.snapshotLocation, ''),
+          util.get(environment, DEFAULT_ENVIRONMENT),
+        ));
+
+        success();
+      }
+    } catch (err) {
+      error(err as Error);
+    }
+  }
+}

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -1,3 +1,8 @@
+// Library dependencies
+import { existsSync } from '../src/deps.ts'
+export { existsSync };
+
+// Test dependencies
 export { 
     assertThrows, 
     assertFalse, 
@@ -8,7 +13,7 @@ export {
     assertGreater,
     assertArrayIncludes 
 } from 'jsr:@std/assert@1.0.13';
-export { assertSpyCalls, spy } from 'jsr:@std/testing@1.0.13/mock';
+export { assertSpyCalls, spy } from 'jsr:@std/testing@1.0.14/mock';
 export { 
     describe, 
     it, 
@@ -16,8 +21,7 @@ export {
     beforeEach, 
     beforeAll, 
     afterEach 
-} from 'jsr:@std/testing@1.0.13/bdd';
+} from 'jsr:@std/testing@1.0.14/bdd';
 export { delay } from 'jsr:@std/async@1.0.13/delay';
-export { existsSync } from 'jsr:@std/fs@1.0.18';
 export { load } from 'jsr:@std/dotenv@0.225.5';
 export * as mf from 'https://deno.land/x/mock_fetch@0.3.0/mod.ts';

--- a/tests/switcher-snapshot.test.ts
+++ b/tests/switcher-snapshot.test.ts
@@ -39,8 +39,9 @@ describe('E2E test - Client local - Snapshot:', function () {
 
   afterAll(function() {
     Client.unloadSnapshot();
-    if (existsSync('generated-snapshots/'))
+    if (existsSync('generated-snapshots/')) {
       Deno.removeSync('generated-snapshots/', { recursive: true });
+    }
   });
 
   it('should NOT update snapshot - Too many requests at checkSnapshotVersion', testSettings, async function () {
@@ -73,7 +74,7 @@ describe('E2E test - Client local - Snapshot:', function () {
       Error, 'Something went wrong: [resolveSnapshot] failed with status 429');
   });
 
-  it('should update snapshot', testSettings, async function () {
+  it('should update snapshot when loading from remote', testSettings, async function () {
     await delay(2000);
 
     // given
@@ -83,15 +84,13 @@ describe('E2E test - Client local - Snapshot:', function () {
 
     // test
     Client.buildContext(contextSettings, {
-      local: true,
       regexSafe: false
     });
     
-    await Client.loadSnapshot();
+    const snapshotVersion = await Client.loadSnapshot();
 
-    assertEquals(Client.snapshotVersion, 0);
-    assertTrue(await Client.checkSnapshot());
-    assertGreater(Client.snapshotVersion, 0);
+    assertExists(GlobalSnapshot.snapshot);
+    assertGreater(snapshotVersion, 0);
   });
 
   it('should update snapshot - store file', testSettings, async function () {

--- a/tests/switcher-snapshot.test.ts
+++ b/tests/switcher-snapshot.test.ts
@@ -87,10 +87,12 @@ describe('E2E test - Client local - Snapshot:', function () {
       regexSafe: false
     });
     
+    assertEquals(Client.snapshotVersion, 0);
     const snapshotVersion = await Client.loadSnapshot();
 
     assertExists(GlobalSnapshot.snapshot);
     assertGreater(snapshotVersion, 0);
+    assertEquals(snapshotVersion, Client.snapshotVersion);
   });
 
   it('should update snapshot - store file', testSettings, async function () {


### PR DESCRIPTION
This pull request refactors the snapshot-watching functionality in the `Client` class by introducing a new `SnapshotWatcher` utility class. It also updates library dependencies and adjusts the corresponding imports. 

### Snapshot-watching refactor:
* [`src/lib/snapshotWatcher.ts`](diffhunk://#diff-39f1f67402b67bda875991b2416567db86432489aa53d79ed66915e5f8557fccR1-R67): Added a new `SnapshotWatcher` class to encapsulate snapshot-watching logic, including debounce handling and file modification detection.
* [`src/client.ts`](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12L47-R57): Replaced the previous snapshot-watching implementation with the new `SnapshotWatcher` class, simplifying the `Client` class and removing redundant code. [[1]](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12L47-R57) [[2]](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12L223-R229) [[3]](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12L276-R241)

### Dependency updates:
* [`src/deps.ts`](diffhunk://#diff-148f36f0a365bdf27732ea65daa5ff8c8a9bb768820a50dd689675ba7df9980eL1-R1): Updated the `existsSync` dependency to version `1.0.19`.
* [`tests/deps.ts`](diffhunk://#diff-57d30fbbf1d1cdb1a5eca860805d6d2f5d96ce1765fbab935fc36b630c707786L11-L21): Updated testing dependencies (`mock` and `bdd`) to version `1.0.14` and adjusted imports accordingly.

### Import adjustments:
* [`src/client.ts`](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12R25): Added import for `SnapshotWatcher` and removed unused imports related to the previous snapshot-watching implementation.
* [`tests/deps.ts`](diffhunk://#diff-57d30fbbf1d1cdb1a5eca860805d6d2f5d96ce1765fbab935fc36b630c707786R1-R5): Added a re-export for `existsSync` from `src/deps.ts` to ensure consistent dependency management across tests.