### PR TITLE
feat: added autoRefreshToken client settings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:2.7.13
+FROM denoland/deno:2.8.0
 
 # Install tools
 RUN apt-get update && \

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Deno v2.7.14
+      - name: Setup Deno v2.8.0
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.7.14
+          deno-version: v2.8.0
 
       - name: Setup LCOV        
         run: sudo apt install -y lcov
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deno-version: [v1.46.3, v2.7.14]
+        deno-version: [v1.46.3, v2.8.0]
         os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,7 +35,7 @@ jobs:
         run: deno task cover
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v8.0.0
+        uses: sonarsource/sonarqube-scan-action@v8.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: env.SONAR_TOKEN != ''
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deno-version: [v1.46.3, v2.8.0]
+        deno-version: [v2.8.0]
         os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
 
@@ -58,10 +58,5 @@ jobs:
         with:
           deno-version: ${{ matrix.deno-version }}
 
-      - name: Run tests (Deno v1)
-        if: "contains(matrix.deno-version, 'v1')"
-        run: deno task test-v1
-
-      - name: Run tests (Deno v2)
-        if: "contains(matrix.deno-version, 'v2')"
+      - name: Run tests
         run: deno task test

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Get PR details
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -51,7 +51,7 @@ jobs:
         run: deno task cover
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v8.0.0
+        uses: sonarsource/sonarqube-scan-action@v8.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: env.SONAR_TOKEN != ''

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,10 +33,10 @@ jobs:
           ref: ${{ steps.pr.outputs.head_sha }}
           fetch-depth: 0
 
-      - name: Setup Deno v2.7.14
+      - name: Setup Deno v2.8.0
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.7.14
+          deno-version: v2.8.0
 
       - name: Setup LCOV        
         run: sudo apt install -y lcov

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A Deno SDK for Switcher API
 
 ### Prerequisites
 
-- **Deno**: Version 1.4x, 2.x or above
+- **Deno**: Version 2.x or above
 - **Permissions**:
 
 | Permission | Required For |
@@ -75,7 +75,6 @@ A Deno SDK for Switcher API
 | `--allow-write` | Writing snapshot files (if enabled) |
 | `--allow-net` | Communicating with the Switcher API |
 | `--allow-env` | Accessing environment variables for configuration |
-| `--unstable-http` | Required for custom SSL certificates in Deno v1.4x (see [Advanced Options](#advanced-options)) |
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Deno SDK for Switcher API
 
 [![Master CI](https://github.com/switcherapi/switcher-client-deno/actions/workflows/master.yml/badge.svg)](https://github.com/switcherapi/switcher-client-deno/actions/workflows/master.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=switcherapi_switcher-client-deno&metric=alert_status)](https://sonarcloud.io/dashboard?id=switcherapi_switcher-client-deno)
+![Known Vulnerabilities](https://snyk.io/test/github/switcherapi/switcher-client-deno/badge.svg)
 [![deno.land/x/switcher4deno](https://shield.deno.dev/x/switcher4deno)](https://deno.land/x/switcher4deno)
 [![JSR](https://jsr.io/badges/@switcherapi/switcher-client-deno)](https://jsr.io/@switcherapi/switcher-client-deno)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -14,9 +15,10 @@ A Deno SDK for Switcher API
 
 </div>
 
-<div align="center">
-  <img src="https://github.com/switcherapi/switcherapi-assets/blob/master/logo/switcherapi_denoclient_transparency_1280.png" alt="Switcher API: Deno Client" />
-</div>
+***
+
+![Switcher API: Deno Client: Cloud-based Feature Flag API](https://github.com/switcherapi/switcherapi-assets/blob/master/logo/switcherapi_deno_client.png)
+
 
 ## Table of Contents
 
@@ -136,7 +138,8 @@ Client.buildContext({
   restrictRelay: true,                  // Relay restrictions in local mode
   regexSafe: true,                      // Prevent reDOS attacks
   certPath: './certs/ca.pem',           // SSL certificate path
-  remoteTimeout: 2000                   // Remote Criteria API timeout (milliseconds)
+  remoteTimeout: 2000,                  // Remote Criteria API timeout (milliseconds)
+  autoRefreshToken: true,               // Automatically refresh auth token before expiration
 });
 ```
 
@@ -157,6 +160,7 @@ Client.buildContext({
 | `regexMaxTimeLimit` | number | Regex timeout in milliseconds |
 | `certPath` | string | Path to SSL certificate file |
 | `remoteTimeout` | number | Remote Criteria API timeout in milliseconds |
+| `autoRefreshToken` | boolean | Automatically refresh auth token before expiration |
 
 > **⚠️ Note on regexSafe**: This feature protects against reDOS attacks but uses Web Workers, which are incompatible with compiled executables.
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,7 +7,6 @@
     "fmt": "deno fmt mod.ts src/ --options-single-quote --options-line-width=120 --check",
     "fmt:fix": "deno fmt mod.ts src/ --options-single-quote --options-line-width=120",
     "test": "deno test --allow-read --allow-net --allow-write --allow-env --allow-import --coverage=coverage",
-    "test-v1": "deno test --allow-read --allow-net --allow-write --allow-env --unstable-http --coverage=coverage",
     "clean": "rm -rf ./npm ./coverage ./generated-snapshots",
     "lcov": "deno coverage coverage --lcov --output=coverage/report.lcov",
     "cover": "deno task clean && deno task test && deno task lcov && genhtml -o coverage/html coverage/report.lcov",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@switcherapi/switcher-client-deno",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Switcher Client Deno is a Feature Flag Deno Client SDK for Switcher API",
   "tasks": {
     "cache-reload": "deno cache --reload --lock=deno.lock mod.ts",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=switcherapi_switcher-client-deno
 sonar.projectName=switcher-client-deno
 sonar.organization=switcherapi
-sonar.projectVersion=2.4.1
+sonar.projectVersion=2.5.0
 
 sonar.javascript.lcov.reportPaths=coverage/report.lcov
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,6 +2,7 @@ import * as remote from './lib/remote.ts';
 import * as util from './lib/utils/index.ts';
 import Bypasser from './lib/bypasser/index.ts';
 import {
+  DEFAULT_AUTO_REFRESH_TOKEN,
   DEFAULT_ENVIRONMENT,
   DEFAULT_FREEZE,
   DEFAULT_LOCAL,
@@ -66,6 +67,7 @@ export class Client {
       local: util.get(options?.local, DEFAULT_LOCAL),
       freeze: util.get(options?.freeze, DEFAULT_FREEZE),
       logger: util.get(options?.logger, DEFAULT_LOGGER),
+      autoRefreshToken: util.get(options?.autoRefreshToken, DEFAULT_AUTO_REFRESH_TOKEN),
     });
 
     // Initialize Auth
@@ -97,6 +99,9 @@ export class Client {
       [SWITCHER_OPTIONS.SNAPSHOT_WATCHER]: () => {
         GlobalOptions.updateOptions({ snapshotWatcher: options.snapshotWatcher });
         this.watchSnapshot();
+      },
+      [SWITCHER_OPTIONS.AUTO_REFRESH_TOKEN]: () => {
+        GlobalOptions.updateOptions({ autoRefreshToken: options.autoRefreshToken });
       },
     };
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,6 +3,7 @@ export const DEFAULT_LOCAL = false;
 export const DEFAULT_FREEZE = false;
 export const DEFAULT_LOGGER = false;
 export const DEFAULT_TEST_MODE = false;
+export const DEFAULT_AUTO_REFRESH_TOKEN = false;
 export const DEFAULT_REGEX_MAX_BLACKLISTED = 50;
 export const DEFAULT_REGEX_MAX_TIME_LIMIT = 3000;
 
@@ -17,4 +18,5 @@ export enum SWITCHER_OPTIONS {
   REGEX_MAX_TIME_LIMIT = 'regexMaxTimeLimit',
   CERT_PATH = 'certPath',
   REMOTE_TIMEOUT = 'remoteTimeout',
+  AUTO_REFRESH_TOKEN = 'autoRefreshToken',
 }

--- a/src/lib/globals/globalAuth.ts
+++ b/src/lib/globals/globalAuth.ts
@@ -1,19 +1,19 @@
 export class GlobalAuth {
-  private static _token?: string;
-  private static _exp?: number;
   private static _url?: string;
+  private static _token: string;
+  private static _exp: number;
 
   static init(url: string | undefined) {
     this._url = url;
-    this._token = undefined;
-    this._exp = undefined;
+    this._token = '';
+    this._exp = 0;
   }
 
   static get token() {
     return this._token;
   }
 
-  static set token(value: string | undefined) {
+  static set token(value: string) {
     this._token = value;
   }
 
@@ -21,7 +21,7 @@ export class GlobalAuth {
     return this._exp;
   }
 
-  static set exp(value: number | undefined) {
+  static set exp(value: number) {
     this._exp = value;
   }
 

--- a/src/lib/globals/globalOptions.ts
+++ b/src/lib/globals/globalOptions.ts
@@ -43,4 +43,8 @@ export class GlobalOptions {
   static get restrictRelay() {
     return this.options.restrictRelay;
   }
+
+  static get autoRefreshToken() {
+    return this.options.autoRefreshToken;
+  }
 }

--- a/src/lib/remoteAuth.ts
+++ b/src/lib/remoteAuth.ts
@@ -1,5 +1,6 @@
 import type { RetryOptions, SwitcherContext } from '../types/index.d.ts';
 import { GlobalAuth } from './globals/globalAuth.ts';
+import { GlobalOptions } from './globals/globalOptions.ts';
 import { auth, checkAPIHealth } from './remote.ts';
 import DateMoment from './utils/datemoment.ts';
 import * as util from './utils/index.ts';
@@ -10,10 +11,30 @@ import * as util from './utils/index.ts';
 export class Auth {
   private static context: SwitcherContext;
   private static retryOptions: RetryOptions;
+  private static refreshTimer: NodeJS.Timeout | undefined;
 
   static init(context: SwitcherContext) {
     this.context = context;
     GlobalAuth.init(context.url);
+  }
+
+  private static scheduleNextAuth() {
+    const msUntilExpiry = (GlobalAuth.exp * 1000) - Date.now();
+    const refreshAt = Math.max(msUntilExpiry - 5000, 0); // 5s before expiry
+
+    this.refreshTimer = setTimeout(() => {
+      this.authUpdate().then(() => {
+        this.scheduleNextAuth();
+      }).catch(() => {
+        this.terminateAutoRefresh();
+      });
+    }, refreshAt);
+  }
+
+  private static async authUpdate() {
+    const response = await auth(this.context);
+    GlobalAuth.token = response.token;
+    GlobalAuth.exp = response.exp;
   }
 
   static setRetryOptions(silentMode: string) {
@@ -23,10 +44,19 @@ export class Auth {
     };
   }
 
+  static terminateAutoRefresh() {
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = undefined;
+    }
+  }
+
   static async auth() {
-    const response = await auth(this.context);
-    GlobalAuth.token = response.token;
-    GlobalAuth.exp = response.exp;
+    await this.authUpdate();
+
+    if (GlobalOptions.autoRefreshToken && !this.refreshTimer) {
+      this.scheduleNextAuth();
+    }
   }
 
   static checkHealth() {

--- a/src/lib/snapshotWatcher.ts
+++ b/src/lib/snapshotWatcher.ts
@@ -10,7 +10,7 @@ import * as util from './utils/index.ts';
  */
 export class SnapshotWatcher {
   private _watcher: Deno.FsWatcher | undefined;
-  private readonly _watchDebounce = new Map<string, number>();
+  private readonly _watchDebounce = new Map<string, NodeJS.Timeout>();
 
   async watchSnapshot(environment: string, callback: {
     success?: () => void | Promise<void>;

--- a/src/lib/utils/snapshotAutoUpdater.ts
+++ b/src/lib/utils/snapshotAutoUpdater.ts
@@ -1,5 +1,5 @@
 export default class SnapshotAutoUpdater {
-  private static _intervalId: number | undefined;
+  private static _intervalId: NodeJS.Timeout | undefined;
 
   static schedule(
     interval: number,
@@ -23,5 +23,6 @@ export default class SnapshotAutoUpdater {
 
   static terminate() {
     clearInterval(this._intervalId);
+    this._intervalId = undefined;
   }
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -122,6 +122,13 @@ export type SwitcherOptions = {
    * If not set, it will use the default value (2000 ms)
    */
   remoteTimeout?: number;
+
+  /**
+   * When enabled it will automatically refresh the token before it expires
+   *
+   * If not set, it will not refresh the token automatically
+   */
+  autoRefreshToken?: boolean;
 };
 
 export type RetryOptions = {

--- a/tests/switcher-integrated.test.ts
+++ b/tests/switcher-integrated.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, assertExists, assertGreater, load } from './deps.ts';
-import { assertTrue } from "./helper/utils.ts";
 
 import { Client } from '../mod.ts';
 
@@ -47,7 +46,7 @@ describe('Switcher integrated test', () => {
         assertGreater(Client.snapshotVersion, 0);
     });
 
-    it('should check Switcher availability', async function () {
+    it('should check Switcher availability', function () {
         if (!Deno.env.get('SWITCHER_API_KEY')) {
             return;
         }
@@ -56,9 +55,7 @@ describe('Switcher integrated test', () => {
         Client.buildContext(contextSettings);
 
         // test
-        await Client.checkSwitchers(['CLIENT_DENO_FEATURE']);
-        
-        assertTrue(true);
+        return Client.checkSwitchers(['CLIENT_DENO_FEATURE']);
     });
 
 });

--- a/tests/switcher-remote.test.ts
+++ b/tests/switcher-remote.test.ts
@@ -4,6 +4,8 @@ import { describe, it, afterAll, afterEach, beforeEach,
 import { given, tearDown, assertTrue, generateAuth, generateResult, generateDetailedResult, sleep } from './helper/utils.ts'
 
 import { Client, type SwitcherResult, type SwitcherContext } from '../mod.ts';
+import { Auth } from "../src/lib/remoteAuth.ts";
+import { GlobalAuth } from "../src/lib/globals/globalAuth.ts";
 import TimedMatch from '../src/lib/utils/timed-match/index.ts';
 import ExecutionLogger from '../src/lib/utils/executionLogger.ts';
 
@@ -337,6 +339,64 @@ describe('Switcher Remote:', function () {
         Error, 'Something went wrong: [checkCriteria] failed with status 429');
     });
 
+  });
+
+  describe('auto refresh token:', function () {
+
+    afterEach(function() {
+      Auth.terminateAutoRefresh();
+    });
+
+    it('should refresh the token before it expires in the background', async function () {
+      // given API responses - 1st auth call
+      given('POST@/criteria/auth', generateAuth('[auth_token_1]', 5));
+      
+      // test
+      Client.buildContext(contextSettings, { autoRefreshToken: true });
+      await Client.getSwitcher('FLAG_1').prepare();
+
+      // given API responses - 2nd auth call (after token expiration)
+      given('POST@/criteria/auth', generateAuth('[auth_token_2]', 5));
+
+      assertEquals(GlobalAuth.token, '[auth_token_1]');
+      await sleep(1000);
+      assertEquals(GlobalAuth.token, '[auth_token_2]');
+    });
+
+    it('should not refresh the token if autoRefreshToken is false', async function () {
+      // given API responses - 1st auth call
+      given('POST@/criteria/auth', generateAuth('[auth_token_1]', 1));
+      
+      // test
+      Client.buildContext(contextSettings, { autoRefreshToken: false });
+      await Client.getSwitcher('FLAG_1').prepare();
+
+      // given API responses - 2nd auth call (after token expiration)
+      given('POST@/criteria/auth', generateAuth('[auth_token_2]', 5));
+
+      assertEquals(GlobalAuth.token, '[auth_token_1]');
+      await sleep(1500);
+      assertEquals(GlobalAuth.token, '[auth_token_1]', 'Token should not have been refreshed');
+    });
+
+    it('should handle token refresh failure gracefully', async function () {
+      const spyTerminate = spy(Auth, 'terminateAutoRefresh');
+
+      // given API responses - 1st auth call
+      given('POST@/criteria/auth', generateAuth('[auth_token_1]', 1));
+      
+      // test
+      Client.buildContext(contextSettings, { autoRefreshToken: true });
+      await Client.getSwitcher('FLAG_1').prepare();
+
+      // given API responses - 2nd auth call (after token expiration) fails
+      given('POST@/criteria/auth', undefined, 500);
+
+      assertEquals(GlobalAuth.token, '[auth_token_1]');
+      await sleep(1500);
+      assertEquals(GlobalAuth.token, '[auth_token_1]', 'Token should not have been refreshed');
+      assertSpyCalls(spyTerminate, 1);
+    });
   });
 
 });


### PR DESCRIPTION
This pull request introduces a new feature for automatic authentication token refresh in the Switcher Deno client, along with several supporting improvements and dependency updates. The most significant change is the addition of the `autoRefreshToken` option, which allows the client to automatically refresh its authentication token before it expires, improving reliability for long-running applications. The update also includes enhancements to documentation, test coverage for the new feature, and updates to dependencies and CI configurations.

**New Feature: Automatic Authentication Token Refresh**
- Added a new `autoRefreshToken` option to the client configuration, enabling automatic background refresh of the authentication token before it expires. This includes logic to schedule token refresh, handle failures gracefully, and a mechanism to terminate the refresh process if needed. [[1]](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12R5) [[2]](diffhunk://#diff-8c943ccfb5928fff63708e99eaafa93f8845c9405ed8e4b32afed23e5003025aR6) [[3]](diffhunk://#diff-8c943ccfb5928fff63708e99eaafa93f8845c9405ed8e4b32afed23e5003025aR21) [[4]](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12R70) [[5]](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12R103-R105) [[6]](diffhunk://#diff-45633372ae0b4f43b5a27fe1c443317334fb640eebe121eff8a1df4d450544f4R3) [[7]](diffhunk://#diff-45633372ae0b4f43b5a27fe1c443317334fb640eebe121eff8a1df4d450544f4R14-R59) [[8]](diffhunk://#diff-45633372ae0b4f43b5a27fe1c443317334fb640eebe121eff8a1df4d450544f4R14-R59) [[9]](diffhunk://#diff-5a8bc5366f7be856ae183794d1790d534c9bc017c047c084f19851e9b2d7d5e6R46-R49) [[10]](diffhunk://#diff-c537e21062bcc8ca608a83ff3c9199cc493566891ce0408203c8e995d57afd96L2-R24)

**Documentation Updates**
- Updated the `README.md` to document the new `autoRefreshToken` option, including usage examples and configuration table. Also refreshed project badges and branding images. (F3f0dec7L3R3, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L139-R142) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R163)

**Test Coverage**
- Added comprehensive tests for the `autoRefreshToken` feature, including scenarios for successful refresh, disabled refresh, and refresh failure. [[1]](diffhunk://#diff-9a8cbe3cb91482b87bc0846b87bb3ae5d8f572697dc35a159c64d1520fc674ccR7-R8) [[2]](diffhunk://#diff-9a8cbe3cb91482b87bc0846b87bb3ae5d8f572697dc35a159c64d1520fc674ccR344-R401)

**Dependency and CI/CD Updates**
- Upgraded Deno version to `2.8.0` in the development container, GitHub Actions workflows, and test matrix. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L1-R1) [[2]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L20-R23) [[3]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L48-R48) [[4]](diffhunk://#diff-9a1c250ec072fc76ad44435cd9462d5693ea81f304d650922d3c2792bef267c2L36-R39)
- Updated project version to `2.5.0` in `deno.jsonc` and `sonar-project.properties`. [[1]](diffhunk://#diff-81342196266f9373572c759839aa5a9ab9942af52ce56316b4855b3df8db588aL3-R3) [[2]](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL4-R4)

**Other Improvements**
- Fixed and clarified type usage for timers in several modules to use `NodeJS.Timeout` for consistency and correctness. [[1]](diffhunk://#diff-39f1f67402b67bda875991b2416567db86432489aa53d79ed66915e5f8557fccL13-R13) [[2]](diffhunk://#diff-8536bf664dce751f5cd28b80fc9902b2cbef19119367b17f9dd7197f4f160087L2-R2) [[3]](diffhunk://#diff-8536bf664dce751f5cd28b80fc9902b2cbef19119367b17f9dd7197f4f160087R26)
- Minor test cleanup and refactoring. [[1]](diffhunk://#diff-ffd4e716943f8bd89d33271ee40a391d79b258e89e20450fe048668517ca5ed8L2) [[2]](diffhunk://#diff-ffd4e716943f8bd89d33271ee40a391d79b258e89e20450fe048668517ca5ed8L50-R49) [[3]](diffhunk://#diff-ffd4e716943f8bd89d33271ee40a391d79b258e89e20450fe048668517ca5ed8L59-R58)

# IMPORTANT
Dropped support for Deno v1