### PR TITLE
chore(deps): bump std/fs@1.0.24 and dev deps

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:2.8.0
+FROM denoland/deno:2.8.1
 
 # Install tools
 RUN apt-get update && \

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
 
   switcherclientdeno:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Deno v2.8.0
+      - name: Setup Deno v2.8.1
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.8.0
+          deno-version: v2.8.1
 
       - name: Setup LCOV        
         run: sudo apt install -y lcov
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deno-version: [v1.46.3, v2.8.0]
+        deno-version: [v1.46.3, v2.8.1]
         os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -33,10 +33,10 @@ jobs:
           ref: ${{ steps.pr.outputs.head_sha }}
           fetch-depth: 0
 
-      - name: Setup Deno v2.8.0
+      - name: Setup Deno v2.8.1
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.8.0
+          deno-version: v2.8.1
 
       - name: Setup LCOV        
         run: sudo apt install -y lcov

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@switcherapi/switcher-client-deno",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Switcher Client Deno is a Feature Flag Deno Client SDK for Switcher API",
   "tasks": {
     "cache-reload": "deno cache --reload --lock=deno.lock mod.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -1,23 +1,23 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/fs@1.0.23": "1.0.23",
-    "jsr:@std/internal@^1.0.12": "1.0.12",
-    "jsr:@std/path@^1.1.4": "1.1.4"
+    "jsr:@std/fs@1.0.24": "1.0.24",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@^1.1.5": "1.1.5"
   },
   "jsr": {
-    "@std/fs@1.0.23": {
-      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
       "dependencies": [
         "jsr:@std/internal",
         "jsr:@std/path"
       ]
     },
-    "@std/internal@1.0.12": {
-      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
     },
-    "@std/path@1.1.4": {
-      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
+    "@std/path@1.1.5": {
+      "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
       "dependencies": [
         "jsr:@std/internal"
       ]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=switcherapi_switcher-client-deno
 sonar.projectName=switcher-client-deno
 sonar.organization=switcherapi
-sonar.projectVersion=2.5.0
+sonar.projectVersion=2.5.1
 
 sonar.javascript.lcov.reportPaths=coverage/report.lcov
 

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,1 +1,1 @@
-export { existsSync } from 'jsr:@std/fs@1.0.23';
+export { existsSync } from 'jsr:@std/fs@1.0.24';

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -14,7 +14,7 @@ export {
     assertStrictEquals,
     assertNotStrictEquals
 } from 'jsr:@std/assert@1.0.19';
-export { assertSpyCalls, spy } from 'jsr:@std/testing@1.0.18/mock';
+export { assertSpyCalls, spy } from 'jsr:@std/testing@1.0.19/mock';
 export { 
     describe, 
     it, 
@@ -22,7 +22,7 @@ export {
     beforeEach, 
     beforeAll, 
     afterEach 
-} from 'jsr:@std/testing@1.0.18/bdd';
-export { delay } from 'jsr:@std/async@1.3.0/delay';
-export { load } from 'jsr:@std/dotenv@0.225.6';
+} from 'jsr:@std/testing@1.0.19/bdd';
+export { delay } from 'jsr:@std/async@1.4.0/delay';
+export { load } from 'jsr:@std/dotenv@0.225.7';
 export * as mf from 'https://deno.land/x/mock_fetch@0.3.0/mod.ts';


### PR DESCRIPTION
This pull request updates the project to use Deno version 2.8.1 and bumps several dependencies to their latest patch versions. It also updates the project version to 2.5.1 and ensures consistency across configuration, workflow, and dependency files.

**Deno version and workflow updates:**

* Updated the Deno base image in `.devcontainer/Dockerfile` to `2.8.1` and changed all workflow references in `.github/workflows/master.yml` and `.github/workflows/sonar.yml` to use Deno `2.8.1` instead of `2.8.0`. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L1-R1) [[2]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L20-R23) [[3]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L48-R48) [[4]](diffhunk://#diff-9a1c250ec072fc76ad44435cd9462d5693ea81f304d650922d3c2792bef267c2L36-R39)

**Dependency updates:**

* Updated `@std/fs` to `1.0.24` in `src/deps.ts`.
* Updated test dependencies in `tests/deps.ts`: `@std/testing` and `@std/assert` to `1.0.19`, `@std/async` to `1.4.0`, and `@std/dotenv` to `0.225.7`.

**Project versioning:**

* Bumped the project version to `2.5.1` in `deno.jsonc` and `sonar-project.properties`. [[1]](diffhunk://#diff-81342196266f9373572c759839aa5a9ab9942af52ce56316b4855b3df8db588aL3-R3) [[2]](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL4-R4)

**Other changes:**

* Removed the `version` field from `.devcontainer/docker-compose.yml` for improved compatibility.